### PR TITLE
Add mapping to fix React error in action

### DIFF
--- a/src/components/ShadowBoxCTA.stories.tsx
+++ b/src/components/ShadowBoxCTA.stories.tsx
@@ -14,6 +14,15 @@ export default {
   component: ShadowBoxCTA,
   decorators: [(story) => <Wrapper>{story()}</Wrapper>],
   title: 'ShadowBoxCTA',
+  argTypes: {
+    action: {
+      control: false,
+      options: ['action'],
+      mapping: {
+        action: ctaAction,
+      },
+    },
+  },
 };
 
 const Story = (args) => <ShadowBoxCTA {...args} />;


### PR DESCRIPTION
This is the mapping code suggested by Kyle Garcia to fix the React error in ShadowCTA. After this change, the action control for ShadowboxCTA will show a hypen and no longer be editable. This is expected.

Next, we have to test to see if this fixes the problems in UXPin.

![image](https://user-images.githubusercontent.com/5798536/159537193-acd463a4-a976-4371-9be3-e79e71e7a669.png)
